### PR TITLE
Add epsilon for making the robot preferring a certain direction

### DIFF
--- a/include/sfm.hpp
+++ b/include/sfm.hpp
@@ -28,7 +28,6 @@
 #include <cmath>
 #include <unordered_map>
 #include <vector>
-#include <iostream>
 
 namespace sfm {
 struct Forces {


### PR DESCRIPTION
As stated in the following paper it may be beneficial to add an epsilon term to make the robot prefer a certain direction for overtaking.

 M. Moussaïd, D. Helbing, S. Garnier, A. Johansson, M. Combe, and G. Theraulaz, “Experi-
mental study of the behavioural mechanisms underlying self-organization in human crowds,”
Proceedings of the Royal Society B: Biological Sciences, vol. 276, pp. 2755 – 2762, 2009.